### PR TITLE
Add support for load localisation via custom file

### DIFF
--- a/UsabillaBindings/Xamarin.Usabilla.Android/Xamarin.Usabilla.Android/UsabillaXamarin.cs
+++ b/UsabillaBindings/Xamarin.Usabilla.Android/Xamarin.Usabilla.Android/UsabillaXamarin.cs
@@ -159,6 +159,7 @@ namespace Xamarin.Usabilla
         public IList<string> DefaultMasks => UsabillaAndroid.UbConstants.DefaultDataMasks;
 
         internal Action<IXUFormCompletionResult> FormCallback { get; set; }
+        public string LocalizedStringFile { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
         private readonly IntentFilter campaignFilter = new IntentFilter(UsabillaAndroid.UbConstants.IntentCloseCampaign);
         private CampaignCloseReceiver campaignReceiver;

--- a/UsabillaBindings/Xamarin.Usabilla.PCL/IUsabillaXamarin.cs
+++ b/UsabillaBindings/Xamarin.Usabilla.PCL/IUsabillaXamarin.cs
@@ -50,5 +50,8 @@ namespace Xamarin.Usabilla.PCL
         void PreloadFeedbackForms(IList<string> formIds);
 
         void RemoveCachedForms();
-    }
+
+        string LocalizedStringFile  { get; set; }
+
+}
 }

--- a/UsabillaBindings/Xamarin.Usabilla.PCL/Xamarin.Usabilla/UsabillaXamarin.cs
+++ b/UsabillaBindings/Xamarin.Usabilla.PCL/Xamarin.Usabilla/UsabillaXamarin.cs
@@ -82,5 +82,18 @@ namespace Xamarin.Usabilla
         {
             throw new NotImplementedException("Dummy Implementation for RemoveCachedForms; should not be called");
         }
+
+        public string LocalizedStringFile
+        {
+            get
+            {
+                throw new NotImplementedException("Dummy Implementation for LocalizedStringFile - get; should not be called");
+            }
+
+            set
+            {
+                throw new NotImplementedException("Dummy Implementation for LocalizedStringFile - set; should not be called");
+            }
+        }
     }
 }

--- a/UsabillaBindings/Xamarin.Usabilla.iOS/UsabillaXamarin.cs
+++ b/UsabillaBindings/Xamarin.Usabilla.iOS/UsabillaXamarin.cs
@@ -238,6 +238,19 @@ namespace Xamarin.Usabilla
             }
         }
 
+        public string LocalizedStringFile
+        {
+            get
+            {
+                return UsabillaIos.Usabilla.LocalizedStringFile;
+            }
+
+            set
+            {
+                UsabillaIos.Usabilla.LocalizedStringFile = value;
+            }
+        }
+
         public void PreloadFeedbackForms(IList<string> formIds)
         {
             string[] formIdArray = null;


### PR DESCRIPTION
### Changelog
- Added support for load localisation via passing custom file name.
 
 **Note : iOS only (should be called like below)**
` if (Device.RuntimePlatform == Device.iOS){ 
    UsabillaXamarin.Instance.LocalizedStringFile = "filename"; 
 }`
 
 
 Where filename will be for ex - **Localizable** if your file is **Localizable.strings**
 
 
 
 ### Before 
 
![Simulator Screen Shot - iPhone 11 - 2021-01-22 at 11 55 57](https://user-images.githubusercontent.com/42991157/105491180-3355db00-5cb6-11eb-9a8a-60ac9b1b856f.png)



### After 

![Simulator Screen Shot - iPhone 11 - 2021-01-22 at 11 56 50](https://user-images.githubusercontent.com/42991157/105491163-2cc76380-5cb6-11eb-9f5f-3741247e651f.png)



